### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This project investigates the dynamics of T cell differentiation in the tumor mi
 ![image](https://github.com/user-attachments/assets/f7cf5462-edfe-4052-b075-171cc6faeee6)
 
 
-Used Seurat to pre-process data, I used Monocle3 to infer the trajectories and pyscenic to infer regulon activty.
+Used Seurat to pre-process data, I used Monocle3 to infer the trajectories and pyscenic to infer regulon activity.
 
 


### PR DESCRIPTION
## Summary
- fix a small typo in the pyscenic description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dec2c4e4083228f45178cf8c9098f